### PR TITLE
#bugfix defined at https://github.com/jcabi/jcabi-w3c/issues/16

### DIFF
--- a/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorITCase.java
+++ b/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorITCase.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 /**
  * Integration case for {@link DefaultHtmlValidator}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
+ * @version $Id: c8f79647cb1da6ce4802f3a0f7bdef46301061c1 $
  * @since 0.8
  */
 public final class DefaultHtmlValidatorITCase {
@@ -62,5 +62,16 @@ public final class DefaultHtmlValidatorITCase {
             Matchers.empty()
         );
     }
-
+    
+    @Test
+    @RetryOnFailure(verbose = false)
+    public void validatesInvalidHtmlDocument() throws Exception {
+        MatcherAssert.assertThat(
+            ValidatorBuilder.HTML.validate(
+            	"this is an invalid html"	
+            ).errors(),
+            Matchers.not(Matchers.empty())
+        );
+    }
+    
 }

--- a/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorITCase.java
+++ b/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorITCase.java
@@ -53,9 +53,15 @@ public final class DefaultHtmlValidatorITCase {
     @RetryOnFailure(verbose = false)
     public void validatesHtmlDocument() throws Exception {
         MatcherAssert.assertThat(
-                        ValidatorBuilder.HTML
-                                        .validate(this.validHtml()).errors(),
-                        Matchers.empty()
+            ValidatorBuilder.HTML.validate(
+                StringUtils.join(
+                    "<!DOCTYPE html>",
+                    "<html><head><meta charset='UTF-8'/>",
+                    "<title>hey</title></head>",
+                    "<body></body></html>"
+                )
+            ).errors(),
+            Matchers.empty()
         );
     }
 
@@ -73,18 +79,4 @@ public final class DefaultHtmlValidatorITCase {
             Matchers.not(Matchers.empty())
         );
     }
-
-    /**
-     * Creates a valid html.
-     * @return Valid html content
-     */
-    private String validHtml() {
-        return StringUtils.join(
-                        "<!DOCTYPE html>",
-                        "<html><head><meta charset='UTF-8'/>",
-                        "<title>hey</title></head>",
-                        "<body></body></html>"
-        );
-    }
-
 }

--- a/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorITCase.java
+++ b/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorITCase.java
@@ -37,41 +37,54 @@ import org.junit.Test;
 
 /**
  * Integration case for {@link DefaultHtmlValidator}.
+ *
  * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id: c8f79647cb1da6ce4802f3a0f7bdef46301061c1 $
+ * @version $Id$
  * @since 0.8
  */
 public final class DefaultHtmlValidatorITCase {
 
     /**
      * DefaultHtmlValidator can validate HTML document.
+     *
      * @throws Exception If something goes wrong inside
      */
     @Test
     @RetryOnFailure(verbose = false)
     public void validatesHtmlDocument() throws Exception {
         MatcherAssert.assertThat(
-            ValidatorBuilder.HTML.validate(
-                StringUtils.join(
-                    "<!DOCTYPE html>",
-                    "<html><head><meta charset='UTF-8'/>",
-                    "<title>hey</title></head>",
-                    "<body></body></html>"
-                )
-            ).errors(),
-            Matchers.empty()
+                        ValidatorBuilder.HTML
+                                        .validate(this.validHtml()).errors(),
+                        Matchers.empty()
         );
     }
-    
+
+    /**
+     * DefaultHtmlValidator can validate invalid HTML document.
+     *
+     * @throws Exception If something goes wrong inside
+     */
     @Test
-    @RetryOnFailure(verbose = false)
     public void validatesInvalidHtmlDocument() throws Exception {
         MatcherAssert.assertThat(
-            ValidatorBuilder.HTML.validate(
-            	"this is an invalid html"	
+                        ValidatorBuilder.HTML.validate(
+                                        "this is an invalid html"
             ).errors(),
             Matchers.not(Matchers.empty())
         );
     }
-    
+
+    /**
+     * Creates a valid html.
+     * @return Valid html content
+     */
+    private String validHtml() {
+        return StringUtils.join(
+                        "<!DOCTYPE html>",
+                        "<html><head><meta charset='UTF-8'/>",
+                        "<title>hey</title></head>",
+                        "<body></body></html>"
+        );
+    }
+
 }

--- a/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorITCase.java
+++ b/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorITCase.java
@@ -73,8 +73,8 @@ public final class DefaultHtmlValidatorITCase {
     @Test
     public void validatesInvalidHtmlDocument() throws Exception {
         MatcherAssert.assertThat(
-                        ValidatorBuilder.HTML.validate(
-                                        "this is an invalid html"
+            ValidatorBuilder.HTML.validate(
+                "this is an invalid html"
             ).errors(),
             Matchers.not(Matchers.empty())
         );

--- a/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
+++ b/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
@@ -63,12 +63,17 @@ public final class DefaultHtmlValidatorTest {
     @Test
     public void validatesHtmlDocument() throws Exception {
         final MkContainer container = new MkGrizzlyContainer().next(
-                        new MkAnswer.Simple(this.validReturn())
+            new MkAnswer.Simple(
+                this.validReturn()
+            )
         ).start();
         final Validator validator = new DefaultHtmlValidator(container.home());
         final ValidationResponse response = validator.validate("<html/>");
         container.stop();
-        MatcherAssert.assertThat(response.toString(), response.valid());
+        MatcherAssert.assertThat(
+            response.toString(),
+            response.valid()
+        );
     }
 
     /**
@@ -179,10 +184,9 @@ public final class DefaultHtmlValidatorTest {
      * @throws IOException if something goes wrong.
      */
     private String invalidHtmlResponse() throws IOException {
-        final InputStream file = DefaultHtmlValidator.class
-           .getResourceAsStream(
+        final InputStream file = DefaultHtmlValidator.class.getResourceAsStream(
                "invalid-html-response.xml"
-           );
+        );
         final String xml = IOUtils.toString(
             file
         );

--- a/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
+++ b/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
@@ -148,17 +148,16 @@ public final class DefaultHtmlValidatorTest {
      * @return Response from W3C.
      */
     private String validReturn() {
-        return StringUtils
-                .join(
-                      "<env:Envelope",
-                      " xmlns:env='http://www.w3.org/2003/05/soap-envelope'>",
-                      "<env:Body><m:markupvalidationresponse",
-                      " xmlns:m='http://www.w3.org/2005/10/markup-validator'>",
-                      "<m:validity>true</m:validity>",
-                      "<m:checkedby>W3C</m:checkedby>",
-                      "<m:doctype>text/html</m:doctype>",
-                      "<m:charset>UTF-8</m:charset>",
-                      "</m:markupvalidationresponse></env:Body></env:Envelope>"
+        return StringUtils.join(
+            "<env:Envelope",
+            " xmlns:env='http://www.w3.org/2003/05/soap-envelope'>",
+            "<env:Body><m:markupvalidationresponse",
+            " xmlns:m='http://www.w3.org/2005/10/markup-validator'>",
+            "<m:validity>true</m:validity>",
+            "<m:checkedby>W3C</m:checkedby>",
+            "<m:doctype>text/html</m:doctype>",
+            "<m:charset>UTF-8</m:charset>",
+            "</m:markupvalidationresponse></env:Body></env:Envelope>"
         );
     }
 

--- a/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
+++ b/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
@@ -78,7 +78,9 @@ public final class DefaultHtmlValidatorTest {
     @Test
     public void validateInvalidHtml() throws Exception {
         final MkContainer container = new MkGrizzlyContainer().next(
-                        new MkAnswer.Simple(this.invalidHtmlResponse())
+            new MkAnswer.Simple(
+                this.invalidHtmlResponse()
+            )
         ).start();
         final Validator validator = new DefaultHtmlValidator(container.home());
         final ValidationResponse response = validator

--- a/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
+++ b/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
@@ -29,98 +29,118 @@
  */
 package com.jcabi.w3c;
 
-import com.jcabi.http.mock.MkAnswer;
-import com.jcabi.http.mock.MkContainer;
-import com.jcabi.http.mock.MkGrizzlyContainer;
+import static org.hamcrest.Matchers.emptyCollectionOf;
+import static org.hamcrest.Matchers.not;
+
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import com.jcabi.http.mock.MkAnswer;
+import com.jcabi.http.mock.MkContainer;
+import com.jcabi.http.mock.MkGrizzlyContainer;
+
 /**
  * Test case for {@link DefaultHtmlValidator}.
+ * 
  * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
+ * @version $Id: 802502850df222023e7cfbb6932b8e9ef0684a2c $
  */
 public final class DefaultHtmlValidatorTest {
 
-    /**
-     * DefaultHtmlValidator can validate HTML document.
-     * @throws Exception If something goes wrong inside
-     */
-    @Test
-    public void validatesHtmlDocument() throws Exception {
-        final MkContainer container = new MkGrizzlyContainer().next(
-            new MkAnswer.Simple(
-                StringUtils.join(
-                    "<env:Envelope",
-                    " xmlns:env='http://www.w3.org/2003/05/soap-envelope'>",
-                    "<env:Body><m:markupvalidationresponse",
-                    " xmlns:m='http://www.w3.org/2005/10/markup-validator'>",
-                    "<m:validity>true</m:validity>",
-                    "<m:checkedby>W3C</m:checkedby>",
-                    "<m:doctype>text/html</m:doctype>",
-                    "<m:charset>UTF-8</m:charset>",
-                    "</m:markupvalidationresponse></env:Body></env:Envelope>"
-                )
-            )
-        ).start();
-        final Validator validator = new DefaultHtmlValidator(container.home());
-        final ValidationResponse response = validator.validate("<html/>");
-        container.stop();
-        MatcherAssert.assertThat(response.toString(), response.valid());
-    }
+	/**
+	 * DefaultHtmlValidator can validate HTML document.
+	 * 
+	 * @throws Exception
+	 *             If something goes wrong inside
+	 */
+	@Test
+	public void validatesHtmlDocument() throws Exception {
+		final MkContainer container = new MkGrizzlyContainer()
+				.next(new MkAnswer.Simple(
+						StringUtils
+								.join("<env:Envelope",
+										" xmlns:env='http://www.w3.org/2003/05/soap-envelope'>",
+										"<env:Body><m:markupvalidationresponse",
+										" xmlns:m='http://www.w3.org/2005/10/markup-validator'>",
+										"<m:validity>true</m:validity>",
+										"<m:checkedby>W3C</m:checkedby>",
+										"<m:doctype>text/html</m:doctype>",
+										"<m:charset>UTF-8</m:charset>",
+										"</m:markupvalidationresponse></env:Body></env:Envelope>")))
+				.start();
+		final Validator validator = new DefaultHtmlValidator(container.home());
+		final ValidationResponse response = validator.validate("<html/>");
+		container.stop();
+		MatcherAssert.assertThat(response.toString(), response.valid());
+	}
 
-    /**
-     * DefaultHtmlValidator throw IOException when W3C server error occurred.
-     * @throws Exception If something goes wrong inside
-     * @todo #10:30min DefaultHtmlValidator have to be updated to throw only
-     *  IOException when W3C validation server is unavailable. Any other
-     *  exception type can be confusing for users. Remove @Ignore annotation
-     *  after finishing implementation.
-     */
-    @Ignore
-    @Test
-    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-    public void throwsIOExceptionWhenValidationServerErrorOccurred()
-        throws Exception {
-        final Set<Integer> responses = new HashSet<Integer>(
-            Arrays.asList(
-                HttpURLConnection.HTTP_INTERNAL_ERROR,
-                HttpURLConnection.HTTP_NOT_IMPLEMENTED,
-                HttpURLConnection.HTTP_BAD_GATEWAY,
-                HttpURLConnection.HTTP_UNAVAILABLE,
-                HttpURLConnection.HTTP_GATEWAY_TIMEOUT,
-                HttpURLConnection.HTTP_VERSION
-            )
-        );
-        final Set<Integer> caught = new HashSet<Integer>();
-        for (final Integer status : responses) {
-            MkContainer container = null;
-            try {
-                container = new MkGrizzlyContainer().next(
-                    new MkAnswer.Simple(status)
-                ).start();
-                new DefaultHtmlValidator(container.home())
-                    .validate("<html></html>");
-            } catch (final IOException ex) {
-                caught.add(status);
-            } finally {
-                container.stop();
-            }
-        }
-        MatcherAssert.assertThat(
-            caught,
-            Matchers.containsInAnyOrder(
-                responses.toArray(new Integer[responses.size()])
-            )
-        );
-    }
+	@Test
+	public void aInvalidHtmlMustReturnValidAsFalseAndContainsAtLeastAnErrorAndAWarning() throws Exception {
+		final MkContainer container = new MkGrizzlyContainer().next(new MkAnswer.Simple(invalidHtmlResponse())).start();
+		final Validator validator = new DefaultHtmlValidator(container.home());
+		final ValidationResponse response = validator.validate("this is an invalid html");
+		container.stop();
+		MatcherAssert.assertThat("Validity must be invalid!", !response.valid());
+		MatcherAssert.assertThat("Must has at least one error", response.errors(), not(emptyCollectionOf(Defect.class)));
+		MatcherAssert.assertThat("Must has at least one warning", response.warnings(), not(emptyCollectionOf(Defect.class)));
+	}
+
+	private String invalidHtmlResponse() throws IOException {
+		final InputStream invalidHtmlResponseFromW3CIS = DefaultHtmlValidator.class.getResourceAsStream("invalid-html-response.xml");
+		final String xml = IOUtils.toString(invalidHtmlResponseFromW3CIS);
+		IOUtils.closeQuietly(invalidHtmlResponseFromW3CIS);
+		return xml;
+	}
+
+	/**
+	 * DefaultHtmlValidator throw IOException when W3C server error occurred.
+	 * 
+	 * @throws Exception
+	 *             If something goes wrong inside
+	 * @todo #10:30min DefaultHtmlValidator have to be updated to throw only
+	 *       IOException when W3C validation server is unavailable. Any other
+	 *       exception type can be confusing for users. Remove @Ignore
+	 *       annotation after finishing implementation.
+	 */
+	@Ignore
+	@Test
+	@SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
+	public void throwsIOExceptionWhenValidationServerErrorOccurred()
+			throws Exception {
+		final Set<Integer> responses = new HashSet<Integer>(Arrays.asList(
+				HttpURLConnection.HTTP_INTERNAL_ERROR,
+				HttpURLConnection.HTTP_NOT_IMPLEMENTED,
+				HttpURLConnection.HTTP_BAD_GATEWAY,
+				HttpURLConnection.HTTP_UNAVAILABLE,
+				HttpURLConnection.HTTP_GATEWAY_TIMEOUT,
+				HttpURLConnection.HTTP_VERSION));
+		final Set<Integer> caught = new HashSet<Integer>();
+		for (final Integer status : responses) {
+			MkContainer container = null;
+			try {
+				container = new MkGrizzlyContainer().next(
+						new MkAnswer.Simple(status)).start();
+				new DefaultHtmlValidator(container.home())
+						.validate("<html></html>");
+			} catch (final IOException ex) {
+				caught.add(status);
+			} finally {
+				container.stop();
+			}
+		}
+		MatcherAssert.assertThat(caught, Matchers.containsInAnyOrder(responses
+				.toArray(new Integer[responses.size()])));
+	}
 
 }

--- a/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
+++ b/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
@@ -82,7 +82,7 @@ public final class DefaultHtmlValidatorTest {
         ).start();
         final Validator validator = new DefaultHtmlValidator(container.home());
         final ValidationResponse response = validator
-                        .validate("this is an invalid html");
+            .validate("this is an invalid html");
         container.stop();
         MatcherAssert.assertThat(
                         "Validity must be invalid!",
@@ -128,10 +128,10 @@ public final class DefaultHtmlValidatorTest {
             MkContainer container = null;
             try {
                 container = new MkGrizzlyContainer().next(
-                                new MkAnswer.Simple(status)
+                    new MkAnswer.Simple(status)
                 ).start();
                 new DefaultHtmlValidator(container.home())
-                                .validate("<html></html>");
+                    .validate("<html></html>");
             } catch (final IOException ex) {
                 caught.add(status);
             } finally {

--- a/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
+++ b/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
@@ -85,17 +85,18 @@ public final class DefaultHtmlValidatorTest {
             .validate("this is an invalid html");
         container.stop();
         MatcherAssert.assertThat(
-                        "Validity must be invalid!",
-                        !response.valid()
+            "Validity must be invalid!",
+            !response.valid()
         );
         MatcherAssert.assertThat(
-                        "Must has at least one error",
-                        response.errors(), this.withoutDefects()
+            "Must has at least one error",
+            response.errors(),
+            this.withoutDefects()
         );
         MatcherAssert.assertThat(
-                        "Must has at least one warning",
-                        response.warnings(),
-                        this.withoutDefects()
+            "Must has at least one warning",
+            response.warnings(),
+            this.withoutDefects()
         );
     }
 

--- a/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
+++ b/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
@@ -133,16 +133,26 @@ public final class DefaultHtmlValidatorTest {
                 container = new MkGrizzlyContainer().next(
                     new MkAnswer.Simple(status)
                 ).start();
-                new DefaultHtmlValidator(container.home())
-                    .validate("<html></html>");
+                new DefaultHtmlValidator(
+                    container.home()
+                ).validate(
+                    "<html></html>"
+                );
             } catch (final IOException ex) {
                 caught.add(status);
             } finally {
                 container.stop();
             }
         }
-        final Integer[] data = responses.toArray(new Integer[responses.size()]);
-        MatcherAssert.assertThat(caught, Matchers.containsInAnyOrder(data));
+        final Integer[] data = responses.toArray(
+            new Integer[responses.size()]
+        );
+        MatcherAssert.assertThat(
+            caught,
+            Matchers.containsInAnyOrder(
+                data
+            )
+        );
     }
 
     /**
@@ -170,9 +180,15 @@ public final class DefaultHtmlValidatorTest {
      */
     private String invalidHtmlResponse() throws IOException {
         final InputStream file = DefaultHtmlValidator.class
-                        .getResourceAsStream("invalid-html-response.xml");
-        final String xml = IOUtils.toString(file);
-        IOUtils.closeQuietly(file);
+           .getResourceAsStream(
+               "invalid-html-response.xml"
+           );
+        final String xml = IOUtils.toString(
+            file
+        );
+        IOUtils.closeQuietly(
+            file
+        );
         return xml;
     }
 
@@ -181,7 +197,11 @@ public final class DefaultHtmlValidatorTest {
      * @return Matcher
      */
     private Matcher<Collection<Defect>> withoutDefects() {
-        return Matchers.not(Matchers.emptyCollectionOf(Defect.class));
+        return Matchers.not(
+            Matchers.emptyCollectionOf(
+                Defect.class
+            )
+        );
     }
 
 }

--- a/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
+++ b/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
@@ -29,118 +29,157 @@
  */
 package com.jcabi.w3c;
 
-import static org.hamcrest.Matchers.emptyCollectionOf;
-import static org.hamcrest.Matchers.not;
-
+import com.jcabi.http.mock.MkAnswer;
+import com.jcabi.http.mock.MkContainer;
+import com.jcabi.http.mock.MkGrizzlyContainer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.jcabi.http.mock.MkAnswer;
-import com.jcabi.http.mock.MkContainer;
-import com.jcabi.http.mock.MkGrizzlyContainer;
-
 /**
  * Test case for {@link DefaultHtmlValidator}.
- * 
+ *
  * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id: 802502850df222023e7cfbb6932b8e9ef0684a2c $
+ * @version $Id$
  */
 public final class DefaultHtmlValidatorTest {
 
-	/**
-	 * DefaultHtmlValidator can validate HTML document.
-	 * 
-	 * @throws Exception
-	 *             If something goes wrong inside
-	 */
-	@Test
-	public void validatesHtmlDocument() throws Exception {
-		final MkContainer container = new MkGrizzlyContainer()
-				.next(new MkAnswer.Simple(
-						StringUtils
-								.join("<env:Envelope",
-										" xmlns:env='http://www.w3.org/2003/05/soap-envelope'>",
-										"<env:Body><m:markupvalidationresponse",
-										" xmlns:m='http://www.w3.org/2005/10/markup-validator'>",
-										"<m:validity>true</m:validity>",
-										"<m:checkedby>W3C</m:checkedby>",
-										"<m:doctype>text/html</m:doctype>",
-										"<m:charset>UTF-8</m:charset>",
-										"</m:markupvalidationresponse></env:Body></env:Envelope>")))
-				.start();
-		final Validator validator = new DefaultHtmlValidator(container.home());
-		final ValidationResponse response = validator.validate("<html/>");
-		container.stop();
-		MatcherAssert.assertThat(response.toString(), response.valid());
-	}
+    /**
+     * DefaultHtmlValidator can validate HTML document.
+     *
+     * @throws Exception If something goes wrong inside
+     */
+    @Test
+    public void validatesHtmlDocument() throws Exception {
+        final MkContainer container = new MkGrizzlyContainer().next(
+                        new MkAnswer.Simple(this.validReturn())
+        ).start();
+        final Validator validator = new DefaultHtmlValidator(container.home());
+        final ValidationResponse response = validator.validate("<html/>");
+        container.stop();
+        MatcherAssert.assertThat(response.toString(), response.valid());
+    }
 
-	@Test
-	public void aInvalidHtmlMustReturnValidAsFalseAndContainsAtLeastAnErrorAndAWarning() throws Exception {
-		final MkContainer container = new MkGrizzlyContainer().next(new MkAnswer.Simple(invalidHtmlResponse())).start();
-		final Validator validator = new DefaultHtmlValidator(container.home());
-		final ValidationResponse response = validator.validate("this is an invalid html");
-		container.stop();
-		MatcherAssert.assertThat("Validity must be invalid!", !response.valid());
-		MatcherAssert.assertThat("Must has at least one error", response.errors(), not(emptyCollectionOf(Defect.class)));
-		MatcherAssert.assertThat("Must has at least one warning", response.warnings(), not(emptyCollectionOf(Defect.class)));
-	}
+    /**
+     * Test if {@link DefaultHtmlValidator} validades invalid html.
+     * @throws Exception If something goes wrong inside
+     */
+    @Test
+    public void validateInvalidHtml() throws Exception {
+        final MkContainer container = new MkGrizzlyContainer().next(
+                        new MkAnswer.Simple(this.invalidHtmlResponse())
+        ).start();
+        final Validator validator = new DefaultHtmlValidator(container.home());
+        final ValidationResponse response = validator
+                        .validate("this is an invalid html");
+        container.stop();
+        MatcherAssert.assertThat(
+                        "Validity must be invalid!",
+                        !response.valid()
+        );
+        MatcherAssert.assertThat(
+                        "Must has at least one error",
+                        response.errors(), this.withoutDefects()
+        );
+        MatcherAssert.assertThat(
+                        "Must has at least one warning",
+                        response.warnings(),
+                        this.withoutDefects()
+        );
+    }
 
-	private String invalidHtmlResponse() throws IOException {
-		final InputStream invalidHtmlResponseFromW3CIS = DefaultHtmlValidator.class.getResourceAsStream("invalid-html-response.xml");
-		final String xml = IOUtils.toString(invalidHtmlResponseFromW3CIS);
-		IOUtils.closeQuietly(invalidHtmlResponseFromW3CIS);
-		return xml;
-	}
+    /**
+     * DefaultHtmlValidator throw IOException when W3C server error occurred.
+     *
+     * @throws Exception If something goes wrong inside
+     * @todo #10:30min DefaultHtmlValidator have to be updated to throw only
+     *  IOException when W3C validation server is unavailable. Any other
+     *  exception type can be confusing for users. Remove @Ignore
+     *  annotation after finishing implementation.
+     */
+    @Ignore
+    @Test
+    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
+    public void throwsIOExceptionWhenValidationServerErrorOccurred()
+        throws Exception {
+        final Set<Integer> responses = new HashSet<Integer>(
+                        Arrays.asList(
+                                      HttpURLConnection.HTTP_INTERNAL_ERROR,
+                                      HttpURLConnection.HTTP_NOT_IMPLEMENTED,
+                                      HttpURLConnection.HTTP_BAD_GATEWAY,
+                                      HttpURLConnection.HTTP_UNAVAILABLE,
+                                      HttpURLConnection.HTTP_GATEWAY_TIMEOUT,
+                                      HttpURLConnection.HTTP_VERSION
+            )
+        );
+        final Set<Integer> caught = new HashSet<Integer>();
+        for (final Integer status : responses) {
+            MkContainer container = null;
+            try {
+                container = new MkGrizzlyContainer().next(
+                                new MkAnswer.Simple(status)
+                ).start();
+                new DefaultHtmlValidator(container.home())
+                                .validate("<html></html>");
+            } catch (final IOException ex) {
+                caught.add(status);
+            } finally {
+                container.stop();
+            }
+        }
+        final Integer[] data = responses.toArray(new Integer[responses.size()]);
+        MatcherAssert.assertThat(caught, Matchers.containsInAnyOrder(data));
+    }
 
-	/**
-	 * DefaultHtmlValidator throw IOException when W3C server error occurred.
-	 * 
-	 * @throws Exception
-	 *             If something goes wrong inside
-	 * @todo #10:30min DefaultHtmlValidator have to be updated to throw only
-	 *       IOException when W3C validation server is unavailable. Any other
-	 *       exception type can be confusing for users. Remove @Ignore
-	 *       annotation after finishing implementation.
-	 */
-	@Ignore
-	@Test
-	@SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-	public void throwsIOExceptionWhenValidationServerErrorOccurred()
-			throws Exception {
-		final Set<Integer> responses = new HashSet<Integer>(Arrays.asList(
-				HttpURLConnection.HTTP_INTERNAL_ERROR,
-				HttpURLConnection.HTTP_NOT_IMPLEMENTED,
-				HttpURLConnection.HTTP_BAD_GATEWAY,
-				HttpURLConnection.HTTP_UNAVAILABLE,
-				HttpURLConnection.HTTP_GATEWAY_TIMEOUT,
-				HttpURLConnection.HTTP_VERSION));
-		final Set<Integer> caught = new HashSet<Integer>();
-		for (final Integer status : responses) {
-			MkContainer container = null;
-			try {
-				container = new MkGrizzlyContainer().next(
-						new MkAnswer.Simple(status)).start();
-				new DefaultHtmlValidator(container.home())
-						.validate("<html></html>");
-			} catch (final IOException ex) {
-				caught.add(status);
-			} finally {
-				container.stop();
-			}
-		}
-		MatcherAssert.assertThat(caught, Matchers.containsInAnyOrder(responses
-				.toArray(new Integer[responses.size()])));
-	}
+    /**
+     * Build a response with valid result from W3C.
+     * @return Response from W3C.
+     */
+    private String validReturn() {
+        return StringUtils
+                .join(
+                      "<env:Envelope",
+                      " xmlns:env='http://www.w3.org/2003/05/soap-envelope'>",
+                      "<env:Body><m:markupvalidationresponse",
+                      " xmlns:m='http://www.w3.org/2005/10/markup-validator'>",
+                      "<m:validity>true</m:validity>",
+                      "<m:checkedby>W3C</m:checkedby>",
+                      "<m:doctype>text/html</m:doctype>",
+                      "<m:charset>UTF-8</m:charset>",
+                      "</m:markupvalidationresponse></env:Body></env:Envelope>"
+        );
+    }
+
+    /**
+     * Use a file to build the request.
+     * @return Request inside the file.
+     * @throws IOException if something goes wrong.
+     */
+    private String invalidHtmlResponse() throws IOException {
+        final InputStream file = DefaultHtmlValidator.class
+                        .getResourceAsStream("invalid-html-response.xml");
+        final String xml = IOUtils.toString(file);
+        IOUtils.closeQuietly(file);
+        return xml;
+    }
+
+    /**
+     * Matcher that checks if has no errors.
+     * @return Matcher
+     */
+    private Matcher<Collection<Defect>> withoutDefects() {
+        return Matchers.not(Matchers.emptyCollectionOf(Defect.class));
+    }
 
 }

--- a/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
+++ b/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
@@ -185,14 +185,10 @@ public final class DefaultHtmlValidatorTest {
      */
     private String invalidHtmlResponse() throws IOException {
         final InputStream file = DefaultHtmlValidator.class.getResourceAsStream(
-               "invalid-html-response.xml"
+            "invalid-html-response.xml"
         );
-        final String xml = IOUtils.toString(
-            file
-        );
-        IOUtils.closeQuietly(
-            file
-        );
+        final String xml = IOUtils.toString(file);
+        IOUtils.closeQuietly(file);
         return xml;
     }
 
@@ -201,11 +197,7 @@ public final class DefaultHtmlValidatorTest {
      * @return Matcher
      */
     private Matcher<Collection<Defect>> withoutDefects() {
-        return Matchers.not(
-            Matchers.emptyCollectionOf(
-                Defect.class
-            )
-        );
+        return Matchers.not(Matchers.emptyCollectionOf(Defect.class));
     }
 
 }

--- a/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
+++ b/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
@@ -149,15 +149,8 @@ public final class DefaultHtmlValidatorTest {
                 container.stop();
             }
         }
-        final Integer[] data = responses.toArray(
-            new Integer[responses.size()]
-        );
-        MatcherAssert.assertThat(
-            caught,
-            Matchers.containsInAnyOrder(
-                data
-            )
-        );
+        final Integer[] data = responses.toArray(new Integer[responses.size()]);
+        MatcherAssert.assertThat(caught, Matchers.containsInAnyOrder(data));
     }
 
     /**

--- a/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
+++ b/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
@@ -114,13 +114,13 @@ public final class DefaultHtmlValidatorTest {
     public void throwsIOExceptionWhenValidationServerErrorOccurred()
         throws Exception {
         final Set<Integer> responses = new HashSet<Integer>(
-                        Arrays.asList(
-                                      HttpURLConnection.HTTP_INTERNAL_ERROR,
-                                      HttpURLConnection.HTTP_NOT_IMPLEMENTED,
-                                      HttpURLConnection.HTTP_BAD_GATEWAY,
-                                      HttpURLConnection.HTTP_UNAVAILABLE,
-                                      HttpURLConnection.HTTP_GATEWAY_TIMEOUT,
-                                      HttpURLConnection.HTTP_VERSION
+            Arrays.asList(
+                HttpURLConnection.HTTP_INTERNAL_ERROR,
+                HttpURLConnection.HTTP_NOT_IMPLEMENTED,
+                HttpURLConnection.HTTP_BAD_GATEWAY,
+                HttpURLConnection.HTTP_UNAVAILABLE,
+                HttpURLConnection.HTTP_GATEWAY_TIMEOUT,
+                HttpURLConnection.HTTP_VERSION
             )
         );
         final Set<Integer> caught = new HashSet<Integer>();

--- a/src/test/resources/com/jcabi/w3c/invalid-html-response.xml
+++ b/src/test/resources/com/jcabi/w3c/invalid-html-response.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope">
+	<env:Body>
+		<m:markupvalidationresponse
+			xmlns:m="http://www.w3.org/2005/10/markup-validator">
+			<m:uri>file</m:uri>
+			<m:checkedby>http://validator.w3.org/</m:checkedby>
+			<m:doctype></m:doctype>
+			<m:charset>utf-8</m:charset>
+			<m:validity>false</m:validity>
+			<m:warnings>
+				<m:warningcount>3</m:warningcount>
+				<m:warninglist>
+					<m:warning>
+						<m:messageid>W04</m:messageid>
+						<m:message>No Character Encoding Found! Falling back to UTF-8.
+						</m:message>
+					</m:warning>
+					<m:warning>
+						<m:messageid>W06</m:messageid>
+						<m:message>Unable to Determine Parse Mode!</m:message>
+					</m:warning>
+					<m:warning>
+						<m:messageid>W27</m:messageid>
+						<m:message>No Character encoding declared at document level
+						</m:message>
+					</m:warning>
+				</m:warninglist>
+			</m:warnings>
+			<m:errors>
+				<m:errorcount>2</m:errorcount>
+				<m:errorlist>
+					<m:error>
+						<m:line>1</m:line>
+						<m:col>1</m:col>
+						<m:message>character &quot;t&quot; not allowed in prolog
+						</m:message>
+						<m:messageid>46</m:messageid>
+						<m:explanation>  <![CDATA[<p class="helpwanted"><a href="feedback.html?uri=;errmsg_id=46#errormsg" title="Suggest improvements on this error message through our feedback channels">&#x2709;</a></p>]]>
+						</m:explanation>
+						<m:source><![CDATA[<strong title="Position where error was detected.">t</strong>his is invalid html]]></m:source>
+					</m:error>
+					<m:error>
+						<m:line>1</m:line>
+						<m:col>21</m:col>
+						<m:message>end of document in prolog</m:message>
+						<m:messageid>47</m:messageid>
+						<m:explanation><![CDATA[<p class="helpwanted"><a href="feedback.html?uri=;errmsg_id=47#errormsg" title="Suggest improvements on this error message through our feedback channels">&#x2709;</a></p><div class="ve mid-47"><p>
+						This error may appear when the validator receives an empty document. Please make sure that the document you are uploading is not empty, and <a href="feedback.html">report</a> any discrepancy.</p></div>]]>
+						</m:explanation>
+						<m:source><![CDATA[this is invalid htm<strong title="Position where error was detected.">l</strong>]]></m:source>
+					</m:error>
+				</m:errorlist>
+			</m:errors>
+		</m:markupvalidationresponse>
+	</env:Body>
+</env:Envelope>

--- a/src/test/resources/com/jcabi/w3c/invalid-html-response.xml
+++ b/src/test/resources/com/jcabi/w3c/invalid-html-response.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope">
+<env:Envelope
+    xmlns:env="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://www.w3.org/2003/05/soap-envelope http://www.w3.org/2003/05/soap-envelope">
     <env:Body>
         <m:markupvalidationresponse
             xmlns:m="http://www.w3.org/2005/10/markup-validator">

--- a/src/test/resources/com/jcabi/w3c/invalid-html-response.xml
+++ b/src/test/resources/com/jcabi/w3c/invalid-html-response.xml
@@ -1,57 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope">
-	<env:Body>
-		<m:markupvalidationresponse
-			xmlns:m="http://www.w3.org/2005/10/markup-validator">
-			<m:uri>file</m:uri>
-			<m:checkedby>http://validator.w3.org/</m:checkedby>
-			<m:doctype></m:doctype>
-			<m:charset>utf-8</m:charset>
-			<m:validity>false</m:validity>
-			<m:warnings>
-				<m:warningcount>3</m:warningcount>
-				<m:warninglist>
-					<m:warning>
-						<m:messageid>W04</m:messageid>
-						<m:message>No Character Encoding Found! Falling back to UTF-8.
-						</m:message>
-					</m:warning>
-					<m:warning>
-						<m:messageid>W06</m:messageid>
-						<m:message>Unable to Determine Parse Mode!</m:message>
-					</m:warning>
-					<m:warning>
-						<m:messageid>W27</m:messageid>
-						<m:message>No Character encoding declared at document level
-						</m:message>
-					</m:warning>
-				</m:warninglist>
-			</m:warnings>
-			<m:errors>
-				<m:errorcount>2</m:errorcount>
-				<m:errorlist>
-					<m:error>
-						<m:line>1</m:line>
-						<m:col>1</m:col>
-						<m:message>character &quot;t&quot; not allowed in prolog
-						</m:message>
-						<m:messageid>46</m:messageid>
-						<m:explanation>  <![CDATA[<p class="helpwanted"><a href="feedback.html?uri=;errmsg_id=46#errormsg" title="Suggest improvements on this error message through our feedback channels">&#x2709;</a></p>]]>
-						</m:explanation>
-						<m:source><![CDATA[<strong title="Position where error was detected.">t</strong>his is invalid html]]></m:source>
-					</m:error>
-					<m:error>
-						<m:line>1</m:line>
-						<m:col>21</m:col>
-						<m:message>end of document in prolog</m:message>
-						<m:messageid>47</m:messageid>
-						<m:explanation><![CDATA[<p class="helpwanted"><a href="feedback.html?uri=;errmsg_id=47#errormsg" title="Suggest improvements on this error message through our feedback channels">&#x2709;</a></p><div class="ve mid-47"><p>
-						This error may appear when the validator receives an empty document. Please make sure that the document you are uploading is not empty, and <a href="feedback.html">report</a> any discrepancy.</p></div>]]>
-						</m:explanation>
-						<m:source><![CDATA[this is invalid htm<strong title="Position where error was detected.">l</strong>]]></m:source>
-					</m:error>
-				</m:errorlist>
-			</m:errors>
-		</m:markupvalidationresponse>
-	</env:Body>
+    <env:Body>
+        <m:markupvalidationresponse
+            xmlns:m="http://www.w3.org/2005/10/markup-validator">
+            <m:uri>file</m:uri>
+            <m:checkedby>http://validator.w3.org/</m:checkedby>
+            <m:doctype></m:doctype>
+            <m:charset>utf-8</m:charset>
+            <m:validity>false</m:validity>
+            <m:warnings>
+                <m:warningcount>3</m:warningcount>
+                <m:warninglist>
+                    <m:warning>
+                        <m:messageid>W04</m:messageid>
+                        <m:message>No Character Encoding Found! Falling
+                            back to UTF-8.
+                        </m:message>
+                    </m:warning>
+                    <m:warning>
+                        <m:messageid>W06</m:messageid>
+                        <m:message>Unable to Determine Parse Mode!
+                        </m:message>
+                    </m:warning>
+                    <m:warning>
+                        <m:messageid>W27</m:messageid>
+                        <m:message>No Character encoding declared at
+                            document level
+                        </m:message>
+                    </m:warning>
+                </m:warninglist>
+            </m:warnings>
+            <m:errors>
+                <m:errorcount>2</m:errorcount>
+                <m:errorlist>
+                    <m:error>
+                        <m:line>1</m:line>
+                        <m:col>1</m:col>
+                        <m:message>character &quot;t&quot; not allowed
+                            in prolog
+                        </m:message>
+                        <m:messageid>46</m:messageid>
+                        <m:explanation>  <![CDATA[<p class="helpwanted"><a href="feedback.html?uri=;errmsg_id=46#errormsg" title="Suggest improvements on this error message through our feedback channels">&#x2709;</a></p>]]>
+                        </m:explanation>
+                        <m:source><![CDATA[<strong title="Position where error was detected.">t</strong>his is invalid html]]></m:source>
+                    </m:error>
+                    <m:error>
+                        <m:line>1</m:line>
+                        <m:col>21</m:col>
+                        <m:message>end of document in prolog</m:message>
+                        <m:messageid>47</m:messageid>
+                        <m:explanation><![CDATA[<p class="helpwanted"><a href="feedback.html?uri=;errmsg_id=47#errormsg" title="Suggest improvements on this error message through our feedback channels">&#x2709;</a></p><div class="ve mid-47"><p>
+This error may appear when the validator receives an empty document. Please make sure that the document you are uploading is not empty, and <a href="feedback.html">report</a> any discrepancy.</p></div>]]>
+                        </m:explanation>
+                        <m:source><![CDATA[this is invalid htm<strong title="Position where error was detected.">l</strong>]]></m:source>
+                    </m:error>
+                </m:errorlist>
+            </m:errors>
+        </m:markupvalidationresponse>
+    </env:Body>
 </env:Envelope>


### PR DESCRIPTION
@dmarkov  PR that refers to issue at https://github.com/jcabi/jcabi-w3c/issues/16

- added new unit test that asserts that an invalid html must 
  return valid
  as false, contains at least one error and and one warning
- added new integration test that validates direct at W3C an invalid
  html and asserts that errors list is not empty