### PR TITLE
DefaultHtmlValidator updated to throw only IOException when W3C validation server is unavailable. 

### DIFF
--- a/src/main/java/com/jcabi/w3c/DefaultHtmlValidator.java
+++ b/src/main/java/com/jcabi/w3c/DefaultHtmlValidator.java
@@ -52,6 +52,11 @@ import lombok.ToString;
 final class DefaultHtmlValidator extends BaseValidator implements Validator {
 
     /**
+     * The HTTP_OK code
+     */
+    private static final int HTTP_OK = 200;
+
+    /**
      * The URI to use in W3C.
      */
     private final transient String uri;
@@ -73,7 +78,7 @@ final class DefaultHtmlValidator extends BaseValidator implements Validator {
             this.entity("uploaded_file", html, MediaType.TEXT_HTML)
         );
         final Response response = req.fetch();
-        if(response.status() != 200) {
+        if (response.status() != HTTP_OK) {
             throw new IOException(
                 response.reason()
             );

--- a/src/main/java/com/jcabi/w3c/DefaultHtmlValidator.java
+++ b/src/main/java/com/jcabi/w3c/DefaultHtmlValidator.java
@@ -52,7 +52,7 @@ import lombok.ToString;
 final class DefaultHtmlValidator extends BaseValidator implements Validator {
 
     /**
-     * The HTTP_OK code
+     * The HTTP_OK code.
      */
     private static final int HTTP_OK = 200;
 

--- a/src/main/java/com/jcabi/w3c/DefaultHtmlValidator.java
+++ b/src/main/java/com/jcabi/w3c/DefaultHtmlValidator.java
@@ -34,6 +34,7 @@ import com.jcabi.http.Request;
 import com.jcabi.http.Response;
 import com.jcabi.http.response.XmlResponse;
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import javax.ws.rs.core.MediaType;
 import lombok.EqualsAndHashCode;
@@ -50,11 +51,6 @@ import lombok.ToString;
 @ToString
 @EqualsAndHashCode(callSuper = false, of = "uri")
 final class DefaultHtmlValidator extends BaseValidator implements Validator {
-
-    /**
-     * The HTTP_OK code.
-     */
-    private static final int HTTP_OK = 200;
 
     /**
      * The URI to use in W3C.
@@ -78,7 +74,7 @@ final class DefaultHtmlValidator extends BaseValidator implements Validator {
             this.entity("uploaded_file", html, MediaType.TEXT_HTML)
         );
         final Response response = req.fetch();
-        if (response.status() != HTTP_OK) {
+        if (response.status() != HttpURLConnection.HTTP_OK) {
             throw new IOException(
                 response.reason()
             );

--- a/src/main/java/com/jcabi/w3c/DefaultHtmlValidator.java
+++ b/src/main/java/com/jcabi/w3c/DefaultHtmlValidator.java
@@ -31,6 +31,7 @@ package com.jcabi.w3c;
 
 import com.jcabi.aspects.Immutable;
 import com.jcabi.http.Request;
+import com.jcabi.http.Response;
 import com.jcabi.http.response.XmlResponse;
 import java.io.IOException;
 import java.net.URI;
@@ -71,8 +72,14 @@ final class DefaultHtmlValidator extends BaseValidator implements Validator {
             this.uri,
             this.entity("uploaded_file", html, MediaType.TEXT_HTML)
         );
+        final Response response = req.fetch();
+        if(response.status() != 200) {
+            throw new IOException(
+                response.reason()
+            );
+        }
         return this.build(
-            req.fetch().as(XmlResponse.class)
+            response.as(XmlResponse.class)
                 .registerNs("env", "http://www.w3.org/2003/05/soap-envelope")
                 .registerNs("m", "http://www.w3.org/2005/10/markup-validator")
                 .assertXPath("//m:validity")

--- a/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
+++ b/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
@@ -40,7 +40,6 @@ import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**

--- a/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
+++ b/src/test/java/com/jcabi/w3c/DefaultHtmlValidatorTest.java
@@ -80,12 +80,7 @@ public final class DefaultHtmlValidatorTest {
     /**
      * DefaultHtmlValidator throw IOException when W3C server error occurred.
      * @throws Exception If something goes wrong inside
-     * @todo #10:30min DefaultHtmlValidator have to be updated to throw only
-     *  IOException when W3C validation server is unavailable. Any other
-     *  exception type can be confusing for users. Remove @Ignore annotation
-     *  after finishing implementation.
      */
-    @Ignore
     @Test
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     public void throwsIOExceptionWhenValidationServerErrorOccurred()


### PR DESCRIPTION
Added HTTP response code check. Any response except 200 OK is wrapped as IOException. 
Fix for https://github.com/jcabi/jcabi-w3c/issues/19