### PR TITLE
DefaultValidationResponse is not immutable

### DIFF
--- a/src/main/java/com/jcabi/w3c/DefaultValidationResponse.java
+++ b/src/main/java/com/jcabi/w3c/DefaultValidationResponse.java
@@ -71,12 +71,14 @@ final class DefaultValidationResponse implements ValidationResponse {
     /**
      * Set of errors found.
      */
-    private final transient Set<Defect> ierrors = new HashSet<Defect>(0);
+    private final transient Set<Defect> ierrors =
+        Collections.synchronizedSet(new HashSet<Defect>(0));
 
     /**
      * Set of warnings found.
      */
-    private final transient Set<Defect> iwarnings = new HashSet<Defect>(0);
+    private final transient Set<Defect> iwarnings =
+        Collections.synchronizedSet(new HashSet<Defect>(0));
 
     /**
      * Public ctor.

--- a/src/main/java/com/jcabi/w3c/ValidationResponse.java
+++ b/src/main/java/com/jcabi/w3c/ValidationResponse.java
@@ -39,7 +39,7 @@ import java.util.Set;
  * <p>See {@link ValidatorBuilder} for explanation of how to get an instance
  * of this interface.
  *
- * <p>Implementation must be immutable and thread-safe.
+ * <p>Implementation may be mutable but thread-safe.
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$


### PR DESCRIPTION
DefaultValidationResponse internal sets wrapped with synchronization to make class immutable.
https://github.com/jcabi/jcabi-w3c/issues/25#