### PR TITLE
Making DefaultCssValidator throw IOException when W3C server it not UP (#20)

### DIFF
--- a/src/main/java/com/jcabi/w3c/DefaultCssValidator.java
+++ b/src/main/java/com/jcabi/w3c/DefaultCssValidator.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.regex.Pattern;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Default implementation of CSS validator.

--- a/src/main/java/com/jcabi/w3c/DefaultCssValidator.java
+++ b/src/main/java/com/jcabi/w3c/DefaultCssValidator.java
@@ -69,8 +69,8 @@ final class DefaultCssValidator extends BaseValidator implements Validator {
     }
 
     // @todo #20:30min introduce a test case to test the success path when
-    // has the pattern below and another one to test the processed path at
-    // this method
+    //  has the pattern below and another one to test the processed path at
+    //  this method
     @Override
     public ValidationResponse validate(final String css)
         throws IOException {

--- a/src/main/java/com/jcabi/w3c/DefaultCssValidator.java
+++ b/src/main/java/com/jcabi/w3c/DefaultCssValidator.java
@@ -121,7 +121,7 @@ final class DefaultCssValidator extends BaseValidator implements Validator {
      */
     private Response correct(final Response response)
         throws IOException {
-        final List<Integer> badStatuses = Arrays.asList(
+        final List<Integer> statuses = Arrays.asList(
             HttpURLConnection.HTTP_INTERNAL_ERROR,
             HttpURLConnection.HTTP_NOT_IMPLEMENTED,
             HttpURLConnection.HTTP_BAD_GATEWAY,
@@ -129,7 +129,7 @@ final class DefaultCssValidator extends BaseValidator implements Validator {
             HttpURLConnection.HTTP_GATEWAY_TIMEOUT,
             HttpURLConnection.HTTP_VERSION
         );
-        if (badStatuses.contains(response.status())) {
+        if (statuses.contains(response.status())) {
             throw new IOException(
                 String.format(
                     "Bad status from W3C server: %1d",

--- a/src/main/java/com/jcabi/w3c/DefaultCssValidator.java
+++ b/src/main/java/com/jcabi/w3c/DefaultCssValidator.java
@@ -68,8 +68,9 @@ final class DefaultCssValidator extends BaseValidator implements Validator {
         this.uri = entry.toString();
     }
 
-    // @todo introduces a test case to validade both process and sucess
-    // paths at this method
+    // @todo #20:30min introduce a test case to test the success path when
+    // has the pattern below and another one to test the processed path at
+    // this method
     @Override
     public ValidationResponse validate(final String css)
         throws IOException {

--- a/src/main/java/com/jcabi/w3c/DefaultCssValidator.java
+++ b/src/main/java/com/jcabi/w3c/DefaultCssValidator.java
@@ -115,7 +115,7 @@ final class DefaultCssValidator extends BaseValidator implements Validator {
     /**
      * Check if response from W3C contains some bad status.
      * @param response Response from W3c.
-     * @return
+     * @return Response passed as parameter.
      * @throws IOException when has some bad status.
      */
     private Response withoutBadResponseStatus(final Response response)

--- a/src/main/java/com/jcabi/w3c/DefaultCssValidator.java
+++ b/src/main/java/com/jcabi/w3c/DefaultCssValidator.java
@@ -69,6 +69,8 @@ final class DefaultCssValidator extends BaseValidator implements Validator {
         this.uri = entry.toString();
     }
 
+    // @todo introduces a test case to validade both process and sucess
+    // paths at this method
     @Override
     public ValidationResponse validate(final String css)
         throws IOException {
@@ -100,8 +102,7 @@ final class DefaultCssValidator extends BaseValidator implements Validator {
             this.uri,
             this.entity("file", DefaultCssValidator.filter(css), "text/css")
         );
-        final Response response = req.fetch();
-        this.assertThatDoesNotHasBadHttpStatusAt(response);
+        final Response response = this.withoutBadResponseStatus(req.fetch());
         return this.build(
             response.as(XmlResponse.class)
                 .registerNs("env", "http://www.w3.org/2003/05/soap-envelope")
@@ -115,9 +116,10 @@ final class DefaultCssValidator extends BaseValidator implements Validator {
     /**
      * Check if response from W3C contains some bad status.
      * @param response Response from W3c.
+     * @return
      * @throws IOException when has some bad status.
      */
-    private void assertThatDoesNotHasBadHttpStatusAt(final Response response)
+    private Response withoutBadResponseStatus(final Response response)
         throws IOException {
         final List<Integer> badStatuses = Arrays.asList(
             HttpURLConnection.HTTP_INTERNAL_ERROR,
@@ -129,12 +131,13 @@ final class DefaultCssValidator extends BaseValidator implements Validator {
         );
         if (badStatuses.contains(response.status())) {
             throw new IOException(
-                StringUtils.join(
-                    "Bad status from W3C server: ",
-                    Integer.toString(response.status())
+                String.format(
+                    "Bad status from W3C server: %1d",
+                    response.status()
                 )
             );
         }
+        return response;
     }
 
     /**

--- a/src/main/java/com/jcabi/w3c/DefaultCssValidator.java
+++ b/src/main/java/com/jcabi/w3c/DefaultCssValidator.java
@@ -102,7 +102,7 @@ final class DefaultCssValidator extends BaseValidator implements Validator {
             this.uri,
             this.entity("file", DefaultCssValidator.filter(css), "text/css")
         );
-        final Response response = this.withoutBadResponseStatus(req.fetch());
+        final Response response = this.correct(req.fetch());
         return this.build(
             response.as(XmlResponse.class)
                 .registerNs("env", "http://www.w3.org/2003/05/soap-envelope")
@@ -119,7 +119,7 @@ final class DefaultCssValidator extends BaseValidator implements Validator {
      * @return Response passed as parameter.
      * @throws IOException when has some bad status.
      */
-    private Response withoutBadResponseStatus(final Response response)
+    private Response correct(final Response response)
         throws IOException {
         final List<Integer> badStatuses = Arrays.asList(
             HttpURLConnection.HTTP_INTERNAL_ERROR,

--- a/src/test/java/com/jcabi/w3c/DefaultCssValidatorTest.java
+++ b/src/test/java/com/jcabi/w3c/DefaultCssValidatorTest.java
@@ -91,10 +91,6 @@ public final class DefaultCssValidatorTest {
     /**
      * DefaultCssValidator throw IOException when W3C server error occurred.
      * @throws Exception If something goes wrong inside
-     * @todo :30min DefaultCssValidator have to be updated to throw only
-     *  IOException when W3C validation server is unavailable. Any other
-     *  exception type can be confusing for users. Remove @Ignore annotation
-     *  after finishing implementation.
      */
     @Test
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")


### PR DESCRIPTION
Solving issue https://github.com/jcabi/jcabi-w3c/issues/20

- Correcting test case that was using DefaultHtmlValidator insteadof DefaultCssValidator
- Cathing exceptions from XML parser and throwing as IOException
- Asserting that all "bad" HTTP response status are throwing IOExcepiton
- Puzzle removed
- New puzzle added to create test cases to success/processed paths at validate method of DefaultCssValidator