### PR TITLE
jcabi-matchers is a runtime dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,6 @@
         <dependency>
             <groupId>com.jcabi</groupId>
             <artifactId>jcabi-matchers</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.grizzly</groupId>


### PR DESCRIPTION
Not sure if I'm missing something, but it seems to me `jcabi-matchers` is a runtime dependency and not just a test one.

It is used by `DefaultHtmlValidator`:
```
java.lang.NoClassDefFoundError: com/jcabi/matchers/XhtmlMatchers
	at com.jcabi.http.response.XmlResponse.assertXPath(XmlResponse.java:142)
	at com.jcabi.w3c.DefaultHtmlValidator.validate(DefaultHtmlValidator.java:87)
```