### PR TITLE
jersey-client is a runtime dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,6 @@
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-client</artifactId>
             <version>1.18.1</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Same issue as #38, when trying to use the CSS validator I realized `jersey-client` is required at runtime...