### PR TITLE
Upgrade jcabi-matchers to 1.9.0 and grizzly to 5.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,13 +98,19 @@
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-matchers</artifactId>
-      <version>1.8.0</version>
+      <version>1.9.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.grizzly</groupId>
       <artifactId>grizzly-http-servlet-server</artifactId>
-      <version>2.4.4</version>
+      <version>5.0.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -130,6 +136,12 @@
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.junit.vintage</groupId>


### PR DESCRIPTION
@yegor256 ready for review.

## What changed

Bumps two `test`-scope dependencies in `pom.xml` to their latest stable releases:

- `com.jcabi:jcabi-matchers`: 1.8.0 -> 1.9.0
- `org.glassfish.grizzly:grizzly-http-servlet-server`: 2.4.4 -> 5.0.1

The grizzly upgrade is the substantive part: 2.4.4 was several years old and unmaintained, while 5.0.1 is the current Eclipse-maintained line.

## Why two extra hunks

A quick `mvn install -Pqulice` after only the version bump fails with:

```
[WARNING] Used undeclared dependencies found:
        org.hamcrest:hamcrest-core:jar:1.3:test
```

Root cause: `grizzly-http-servlet-server-2.4.4.jar` ships with `org/hamcrest/*` classes embedded inside it (its build uses `maven-bundle-plugin` with `<unpackBundle>true</unpackBundle>` and `<Embed-Dependency>`). The maven-dependency-analyzer therefore attributed the test-code references to `org.hamcrest.MatcherAssert` / `Matchers` to grizzly itself, hiding the fact that the project never declared hamcrest. Grizzly 5.0.1 no longer embeds those classes, so the analyzer falls back to `hamcrest-core:1.3` (transitively pulled by `junit:4.13.2`) which is undeclared, and qulice fails the build.

The fix:

1. Declare `org.hamcrest:hamcrest:3.0` (test scope) explicitly - the project already used it via jcabi-matchers' compile-scope transitive, this just makes the dependency real.
2. Exclude the obsolete `org.hamcrest:hamcrest-core:1.3` from `junit:4.13.2`. `hamcrest-core` was superseded by the unified `hamcrest` artifact and is no longer needed.

## Verification

- Local: `mvn --errors --batch-mode -ntp clean install -Pqulice -DskipITs` -> BUILD SUCCESS, qulice clean.
- CI: all 11 checks green (mvn x3 OS, plus actionlint / copyrights / markdown-lint / pdd / reuse / typos / xcop / yamllint).
- Integration tests against the live W3C validator weren't run locally (sandbox can't reach `validator.w3.org`); CI runs them and they pass.
